### PR TITLE
Patching CVE-2020-8175

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/nsfw-filter/gif-frames#readme",
   "dependencies": {
     "@nsfw-filter/save-pixels": "^2.3.4",
-    "get-pixels-frame-info-update": "3.3.2",
+    "get-pixels-updated": "1.0.0",
     "multi-integer-range": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I made [a fork](https://github.com/sysollie/get-pixels-updated) of [get-pixels](https://github.com/scijs/get-pixels) so I could patch the [CVE-2020-8175](https://github.com/advisories/GHSA-w7q9-p3jq-fmhm) security issue. Everything under the hood is the same - you can check if you want - only the package.json file and README.md file has been updated.

You may have to make sure it is still compatible before merging (even though it most likely is), I haven't.